### PR TITLE
Get rid of duplicate definitions that trip up typescript

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -32,12 +32,6 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, app, data
     setIsLoading(isLoading.slice(1));
   };
 
-  const isInDashboard = useMemo(() => app === 'panel-editor', [app]);
-
-  const getTimeStampColumnName = () => {
-    return datasource.instanceSettings?.jsonData?.timestamp_column || '_timestamp';
-  };
-
   useEffect(() => {
     startLoading();
     getOrganizations({ url: datasource.url, page_num: 0, page_size: 1000, sort_by: 'id' })


### PR DESCRIPTION
Two variables in QueryEditor.tsx were duplicated (and identical): isInDashboard and getTimeStampColumnName. This change deletes the second one, which makes typescript happy.

This fixes #14.