### PR TITLE
Dataframe parsing bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-deprecation": "^2.0.0"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -32,12 +32,6 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, app, data
     setIsLoading(isLoading.slice(1));
   };
 
-  const isInDashboard = useMemo(() => app === 'panel-editor', [app]);
-
-  const getTimeStampColumnName = () => {
-    return datasource.instanceSettings?.jsonData?.timestamp_column || '_timestamp';
-  };
-
   useEffect(() => {
     startLoading();
     getOrganizations({ url: datasource.url, page_num: 0, page_size: 1000, sort_by: 'id' })

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -72,7 +72,7 @@ export class DataSource
 
       // As we don't show histogram for sql mode in explore
       if (options.app === 'explore' && target?.refId?.includes(REF_ID_STARTER_LOG_VOLUME) && target.sqlMode) {
-        return getGraphDataFrame([], target, options.app);
+        return getGraphDataFrame([], target, options.app, this.timestampColumn);
       }
 
       this.cachedQuery.requestQuery = JSON.stringify(reqData);
@@ -80,12 +80,12 @@ export class DataSource
       return this.doRequest(target, reqData)
         .then((response) => {
           if (options.app === 'panel-editor' || options.app === 'dashboard') {
-            return getGraphDataFrame(response.hits, target, options.app);
+            return getGraphDataFrame(response.hits, target, options.app, this.timestampColumn);
           }
 
           const logsDataFrame = getLogsDataFrame(response.hits, target, this.streamFields, this.timestampColumn);
 
-          const graphDataFrame = getGraphDataFrame(response?.aggs?.histogram || [], target, options.app);
+          const graphDataFrame = getGraphDataFrame(response?.aggs?.histogram || [], target, options.app, this.timestampColumn);
 
           this.cachedQuery.promise?.resolve({ graph: graphDataFrame, logs: logsDataFrame });
 

--- a/src/features/log/queryResponseBuilder.ts
+++ b/src/features/log/queryResponseBuilder.ts
@@ -49,6 +49,8 @@ export const getGraphDataFrame = (data: any, target: MyQuery, app: string) => {
     }
   }
 
+  for (let i = 0; i < fields.length; i++) {
+    if (fields[i] === '_timestamp') {
   graphData.addField({
     config: {
       filterable: true,
@@ -56,12 +58,11 @@ export const getGraphDataFrame = (data: any, target: MyQuery, app: string) => {
     name: 'Time',
     type: FieldType.time,
   });
-
-  for (let i = 1; i < fields.length; i++) {
+    } else {
     graphData.addField({
       name: fields[i],
-      type: FieldType.number,
     });
+    }
   }
 
   if (!data.length) {

--- a/src/features/log/queryResponseBuilder.ts
+++ b/src/features/log/queryResponseBuilder.ts
@@ -69,19 +69,31 @@ export const getGraphDataFrame = (data: any, target: MyQuery, app: string) => {
   }
 
   data.forEach((log: any) => {
-    graphData.add(getField(log, fields));
+    graphData.add(getField(log, fields, '_timestamp'));
   });
 
   return graphData;
 };
 
-const getField = (log: any, columns: any) => {
-  let field: any = {
-    Time: new Date(log[columns[0]] + 'Z').getTime(),
-  };
+const getField = (log: any, columns: any, timestampColumn: string) => {
+  let field: any = {};
 
-  for (let i = 1; i < columns.length; i++) {
-    field[columns[i]] = log[columns[i]];
+  for (let i = 0; i < columns.length; i++) {
+    let col_name = columns[i];
+    let col_value = log[col_name]
+    if (col_name === timestampColumn) {
+      // We have to convert microseconds if we receive them
+      // 500 billion / year 17814 is probably a good threshold for milliseconds
+      if (col_value > 500_000_000_000) {
+        col_value = convertTimeToMs(col_value);
+        field["Time"] = col_value;
+      } else {
+        // Convert any other date fmt
+        field["Time"] = new Date(col_value).getTime();
+      }
+    } else {
+      field[col_name] = log[col_name];
+    }
   }
 
   return field;

--- a/src/features/log/queryResponseBuilder.ts
+++ b/src/features/log/queryResponseBuilder.ts
@@ -36,7 +36,12 @@ export const getLogsDataFrame = (
   return logsData;
 };
 
-export const getGraphDataFrame = (data: any, target: MyQuery, app: string) => {
+export const getGraphDataFrame = (
+  data: any,
+  target: MyQuery,
+  app: string,
+  timestampColumn = '_timestamp'
+) => {
   const graphData = getDefaultDataFrame(target.refId, 'graph');
 
   let fields = ['zo_sql_key', 'zo_sql_num'];
@@ -50,7 +55,7 @@ export const getGraphDataFrame = (data: any, target: MyQuery, app: string) => {
   }
 
   for (let i = 0; i < fields.length; i++) {
-    if (fields[i] === '_timestamp') {
+    if (fields[i] === timestampColumn) {
       graphData.addField({
         config: {
           filterable: true,
@@ -70,7 +75,7 @@ export const getGraphDataFrame = (data: any, target: MyQuery, app: string) => {
   }
 
   data.forEach((log: any) => {
-    graphData.add(getField(log, fields, '_timestamp'));
+    graphData.add(getField(log, fields, timestampColumn));
   });
 
   return graphData;

--- a/src/features/log/queryResponseBuilder.ts
+++ b/src/features/log/queryResponseBuilder.ts
@@ -51,17 +51,17 @@ export const getGraphDataFrame = (data: any, target: MyQuery, app: string) => {
 
   for (let i = 0; i < fields.length; i++) {
     if (fields[i] === '_timestamp') {
-  graphData.addField({
-    config: {
-      filterable: true,
-    },
-    name: 'Time',
-    type: FieldType.time,
-  });
+      graphData.addField({
+        config: {
+          filterable: true,
+        },
+        name: 'Time',
+        type: FieldType.time,
+      });
     } else {
-    graphData.addField({
-      name: fields[i],
-    });
+      graphData.addField({
+        name: fields[i],
+      });
     }
   }
 
@@ -140,7 +140,9 @@ const getColumnsFromQuery = (query: string) => {
 
     // If alias exists, use that, otherwise use column name
     if (aliasMatch) {
-      columnNames.push(aliasMatch[1]);
+      // SQL alias may have quotes, strip those.
+      let stripped = aliasMatch[1].replace(/^['"]|['"]$/g, '');
+      columnNames.push(stripped);
     } else {
       columnNames.push(column);
     }


### PR DESCRIPTION
This change set fixes several bugs in the Grafana dashboard plugin.

# Bugs encountered
* Missing parameters in requests
* Columns forced as ints
* Timestamp when not requested or relevant
* Timestamp not translated properly / broken outside of Explore view 
```
 SELECT distinct(agent_hostname) as agent_hostname  FROM "apache_log" 
```
^ Attempting such a query would return nothing or NaN

This query would also fail to render in any view outside of Explore
```
select 1 from "log_stream"
```
# Fixes
## getField
* Fix bug which skips the first column regardless of if it is a timestamp
* date(timestamp + "Z") was breaking timestamps. Use whatever Open Observe gives us, unless it's microseconds which needs converting to MS.
* Only add Time column if it's part of the request [breaking for queries relying on this implicit field, but deduplicating for the queries that manually request it including example requests]

## getGraphDataFrame
* [bugfix] No longer skip first requested column
* [bugfix] Remove type: number for non-time fields which breaks string responses
* Detect timestamp column in request
* Utilize datasource defined timestamp column automatically in data frame parser

## getColumnsFromQuery
* [bug] The dataframe parser would fail to assign fields wrapped in quotes i.e. select 1 as "server". Strip quotes.


Additionally, fixes for #14 are included so tests pass but if #15 is merged ahead of this I can revert [8561dab327348cb1dffc5b366a1a9d511b827069](https://github.com/openobserve/openobserve-grafana-plugin/commit/8561dab327348cb1dffc5b366a1a9d511b827069)


