### PR TITLE
fix the issue with logs and table visualzation in dashboards

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -17,6 +17,8 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, app, data
   const [orgOptions, setOrgOptions]: any = useState([]);
   const [isMounted, setIsMounted]: any = useState(false);
   const [isLoading, setIsLoading]: any = useState([]);
+  const [displayOptions, setDisplayOptions]: any = useState([]);
+
 
   const isInDashboard = useMemo(() => app === 'panel-editor', [app]);
 
@@ -31,6 +33,14 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, app, data
   const stopLoading = () => {
     setIsLoading(isLoading.slice(1));
   };
+
+  useEffect(() => {
+    setDisplayOptions([
+      { label: 'Auto', value: 'auto' },
+      { label: 'Force Graph', value: 'graph' },
+      { label: 'Force Logs', value: 'logs' },
+    ]);
+  }, []);
 
   useEffect(() => {
     startLoading();
@@ -66,6 +76,7 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, app, data
                 stream: streams[0].name,
                 organization: orgs.data[0].name,
                 sqlMode: isInDashboard ? true : false,
+                displayMode: query.displayMode ?? 'auto'
               });
             } else if (isInDashboard && query.organization && query.stream && query.query) {
               updateQuery();
@@ -135,6 +146,11 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, app, data
       query: newQuery,
       sqlMode: query.sqlMode,
     });
+  };
+
+  const onDisplayModeChange = (displayMode: any) => {
+    const newMode = displayMode.value as MyQuery['displayMode'];
+    onChange({ ...query, displayMode: newMode });
   };
 
   const onChangeQuery = ({ value, sqlMode }: { value: string; sqlMode: boolean }) => {
@@ -266,6 +282,18 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, app, data
           <Switch data-testid="query-editor-sql-mode-switch" value={!!query.sqlMode} onChange={toggleSqlMode} />
         </div>
       )}
+      {/* Display Mode selector */}
+      <div className={css`display: flex; align-items: center; padding-bottom: 0.5rem;`}>
+        <InlineLabel className={css`width: fit-content;`} transparent>
+          Display Mode
+        </InlineLabel>
+        <Select
+          options={displayOptions}
+          value={displayOptions.find((o: any) => o.value === query.displayMode) || displayOptions[0]}
+          onChange={onDisplayModeChange}
+          width={20}
+        />
+      </div>
       {query.stream && (
         <ZincEditor
           key={generateEditorId}

--- a/src/features/log/queryResponseBuilder.ts
+++ b/src/features/log/queryResponseBuilder.ts
@@ -2,6 +2,9 @@ import { FieldType, MutableDataFrame, PreferredVisualisationType } from '@grafan
 import { MyQuery } from '../../types';
 import { convertTimeToMs, getFieldType } from '../../utils/zincutils';
 
+const isTimeField = (name: string, timestampColumn: string): boolean =>
+  name === timestampColumn || name.startsWith('x_axis');
+
 export const getLogsDataFrame = (
   data: any,
   target: MyQuery,
@@ -55,7 +58,7 @@ export const getGraphDataFrame = (
   }
 
   for (let i = 0; i < fields.length; i++) {
-    if (fields[i] === timestampColumn) {
+    if (isTimeField(fields[i],timestampColumn)) {
       graphData.addField({
         config: {
           filterable: true,
@@ -87,7 +90,7 @@ const getField = (log: any, columns: any, timestampColumn: string) => {
   for (let i = 0; i < columns.length; i++) {
     let col_name = columns[i];
     let col_value = log[col_name]
-    if (col_name === timestampColumn) {
+    if (isTimeField(col_name, timestampColumn)) {
       // We have to convert microseconds if we receive them
       // 500 billion / year 17814 is probably a good threshold for milliseconds
       if (col_value > 500_000_000_000) {

--- a/src/features/log/queryResponseBuilder.ts
+++ b/src/features/log/queryResponseBuilder.ts
@@ -58,7 +58,7 @@ export const getGraphDataFrame = (
   }
 
   for (let i = 0; i < fields.length; i++) {
-    if (isTimeField(fields[i],timestampColumn)) {
+    if (isTimeField(fields[i], timestampColumn)) {
       graphData.addField({
         config: {
           filterable: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,10 +12,12 @@ export interface MyQuery extends DataQuery {
     rows: number;
   };
   streamFields: any[];
+  displayMode?: 'auto' | 'graph' | 'logs';
 }
 
 export const DEFAULT_QUERY: Partial<MyQuery> = {
   constant: 6.5,
+  displayMode: 'auto',
 };
 
 /**


### PR DESCRIPTION
There was an issue where you couldnt have the logs or table visualation in dashboards because it would always return the graph format. 

I've added a selector to select the type of dataframe you want to return (log/graph).